### PR TITLE
fix: retrofit `wgo` to build on older go versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@v3
       - name: Install go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '>=1.18.0'
+          go-version: '1.16.0'
       - name: Install goveralls
         run: go install github.com/mattn/goveralls@latest
       - run: go test . -coverprofile=coverage -race

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/bokwoon95/wgo
 
-go 1.19
+go 1.11
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/go-cmp v0.5.9
 )
-
-require golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bokwoon95/wgo
 
-go 1.11
+go 1.16
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/wgo_cmd_test.go
+++ b/wgo_cmd_test.go
@@ -446,7 +446,7 @@ func TestWgoCmd_Run(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf := &bytes.Buffer{}
+		buf := &Buffer{}
 		wgoCmd.Stdout = buf
 		err = wgoCmd.Run()
 		if err != nil {
@@ -467,7 +467,7 @@ func TestWgoCmd_Run(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf := &bytes.Buffer{}
+		buf := &Buffer{}
 		wgoCmd.Stdout = buf
 		err = wgoCmd.Run()
 		if err != nil {
@@ -488,7 +488,7 @@ func TestWgoCmd_Run(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf := &bytes.Buffer{}
+		buf := &Buffer{}
 		wgoCmd.Stdout = buf
 		err = wgoCmd.Run()
 		if err != nil {
@@ -509,7 +509,7 @@ func TestWgoCmd_Run(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf := &bytes.Buffer{}
+		buf := &Buffer{}
 		cmd.Stdout = buf
 		err = cmd.Run()
 		if err != nil {
@@ -643,7 +643,7 @@ func TestWgoCmd_FileEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	buf := &bytes.Buffer{}
+	buf := &Buffer{}
 	wgoCmd.Stdout = buf
 	cmdResult := make(chan error)
 	go func() {
@@ -721,7 +721,7 @@ func TestStdin(t *testing.T) {
 		t.Fatal(err)
 	}
 	wgoCmd.Stdin = strings.NewReader("foo\nbar\nbaz")
-	buf := &bytes.Buffer{}
+	buf := &Buffer{}
 	wgoCmd.Stderr = buf
 	err = wgoCmd.Run()
 	if err != nil {


### PR DESCRIPTION
It seems like a minor tweak making `wgo` build possible on older `go` environments, down to 1.16. 
