### PR TITLE
docs: remove shell prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```shell
-$ go install github.com/bokwoon95/wgo@latest
+go install github.com/bokwoon95/wgo@latest
 ```
 
 ```text


### PR DESCRIPTION
Remove the shell prefix so that the user can just copy ( with the github copy button ) and paste it on the terminal immediately. 