### PR TITLE
feat: implement -exec-msg -exec-log -log-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ $ wgo run -tags=fts5 -race -trimpath main.go
 - [-exit](#exit-when-the-last-command-exits) - Exit when the last command exits.
 - [-stdin](#enable-stdin) - Enable stdin for the last command.
 - [-verbose](#log-file-events) - Log file events.
+- [-exec-msg](#exec-message) - Prefix the EXECUTING log line with a message.
+- [-exec-log](#exec-log) - Log the EXECUTING line without verbose file events.
+- [-log-prefix](#log-prefix) - Override the default log prefix.
 - [-debounce](#debounce-duration) - How quickly to react to file events. Lower debounce values will react quicker.
 - [-postpone](#postpone-the-first-execution-of-the-command-until-a-file-is-modified) - Postpone the first execution of the command until a file is modified.
 - [-poll](#use-polling-to-detect-file-changes) - How often to poll for file changes. Zero or no value means no polling.
@@ -357,6 +360,43 @@ Listening on localhost:8080
 [wgo] CREATE server/main.go
 [wgo] WRITE server/main.go
 Listening on localhost:8080
+```
+
+## Exec message
+
+[*back to flags index*](#flags)
+
+Prefix the EXECUTING log line with a custom message (useful when running
+multiple watchers). This message is shown whenever the EXECUTING line is
+enabled (via -verbose or -exec-log).
+
+```shell
+$ wgo run -verbose -exec-msg "Watcher > Scheduler" ./cmd/scheduler
+[wgo] Watcher > Scheduler EXECUTING /bin/sh -c /path/to/wgo_...
+```
+
+## Exec log
+
+[*back to flags index*](#flags)
+
+Log the EXECUTING line without turning on verbose file event logging.
+
+```shell
+$ wgo -exec-log -exec-msg "Watcher > Scheduler" ./cmd/scheduler
+[wgo] Watcher > Scheduler EXECUTING /bin/sh -c ./cmd/scheduler
+```
+
+## Log prefix
+
+[*back to flags index*](#flags)
+
+Override the default `[wgo]` or `[wgoN]` log prefix. Include any trailing
+space you want in the prefix. Pass an empty value to disable the prefix
+entirely.
+
+```shell
+$ wgo -log-prefix "[dev] " -exec-log -exec-msg "API" ./cmd/server
+[dev] API EXECUTING /bin/sh -c ./cmd/server
 ```
 
 ## Debounce duration

--- a/wgo_cmd_test.go
+++ b/wgo_cmd_test.go
@@ -380,7 +380,7 @@ func TestWgoCommands(t *testing.T) {
 	}, {
 		description: "wgo flags",
 		args: []string{
-			"wgo", "-root", "/secrets", "-file", ".", "-verbose", "-postpone", "echo", "hello",
+			"wgo", "-root", "/secrets", "-file", ".", "-exec-log", "-log-prefix", "[custom] ", "-postpone", "echo", "hello",
 		},
 		wantCmds: []*WgoCmd{{
 			Roots:       []string{".", "/secrets"},
@@ -390,6 +390,8 @@ func TestWgoCommands(t *testing.T) {
 			},
 			Debounce: 300 * time.Millisecond,
 			Postpone: true,
+			ExecLog:  true,
+			LogPrefix: "[custom] ",
 		}},
 	}, {
 		description: "escaped ::",
@@ -445,7 +447,7 @@ func TestWgoCommands(t *testing.T) {
 			}
 			opts := []cmp.Option{
 				// Comparing loggers always fails, ignore it.
-				cmpopts.IgnoreFields(WgoCmd{}, "Logger"),
+				cmpopts.IgnoreFields(WgoCmd{}, "Logger", "logPrefix", "logExecuting"),
 			}
 			if diff := Diff(gotCmds, tt.wantCmds, opts...); diff != "" {
 				t.Error(diff)


### PR DESCRIPTION
First of all - thank you for wgo, it's been fantastic and I've been sharing it widely.

This PR implements some functionality I've needed for my use cases - I'm happy to change things or simply maintain some of these things in my own fork if you don't vibe with them.

**Use Case**

I have a development watcher running 5 or so different processes which are running sub wgo commands. When developing I really would like to be able to see which watcher is triggering for which and it's not clear what's happening without flipping on -verbose - which gives me far more than I ideally want.

**Example**

<img width="1748" height="1766" alt="Screenshot 2026-01-08 at 6 20 25 PM" src="https://github.com/user-attachments/assets/8c982159-7419-42b5-b1a2-83923a919a8b" />

Example config looks like this

```yaml
dev_watches:
  - name: Build App
    watch: "-file .go -file .env -xdir forj -xdir _data"
    exec: "go build -o ./bin/app"
  - name: API
    watch: "-file ./bin/app"
    exec: "./bin/app http:serve"
  - name: Scheduler
    watch: "-file ./bin/app"
    exec: "./bin/app schedule:run"
  - name: Jobs
    watch: "-file ./bin/app"
    exec: "./bin/app queue:work"
  - name: Wire
    watch: -file .go -cd ./wire -xfile ./wire/wire_gen.go -xdir forj -postpone
    exec: wire
```

**Changes**

* Added -exec-msg to prefix the EXECUTING line with a custom label.
* Added -exec-log to show EXECUTING without enabling verbose file-event logs.
* Added -log-prefix to override or disable the default [wgo]/[wgoN] prefix.
* Updated README with new flags and examples.

**Tests**

* Tests pass locally